### PR TITLE
fix `purpose` overriding `presentationPurpose` on _verifyPresentation()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -290,7 +290,7 @@ async function _verifyCredential(options = {}) {
   });
 
   const result = await jsigs.verify(
-    credential, {purpose, documentLoader, ...options});
+    credential, {...options, purpose, documentLoader});
 
   // if verification has already failed, skip status check
   if(!result.verified) {
@@ -382,7 +382,7 @@ export async function signPresentation(options = {}) {
 
   const documentLoader = options.documentLoader || defaultDocumentLoader;
 
-  return jsigs.sign(presentation, {purpose, documentLoader, ...options});
+  return jsigs.sign(presentation, {...options, purpose, documentLoader});
 }
 
 /**
@@ -441,7 +441,7 @@ async function _verifyPresentation(options = {}) {
   if(credentials.length > 0) {
     // verify every credential in `verifiableCredential`
     credentialResults = await Promise.all(credentials.map(credential => {
-      return verifyCredential({credential, documentLoader, ...options});
+      return verifyCredential({...options, credential, documentLoader});
     }));
 
     for(const [i, credentialResult] of credentialResults.entries()) {
@@ -469,7 +469,7 @@ async function _verifyPresentation(options = {}) {
     new AuthenticationProofPurpose({controller, domain, challenge});
 
   const presentationResult = await jsigs.verify(
-    presentation, {purpose, documentLoader, ...options});
+    presentation, {...options, purpose, documentLoader});
 
   return {
     presentationResult,


### PR DESCRIPTION
When composing an object, entries to the right take precedence over entries to the left. Overrides should thus be positioned to the right of the `...options` spread. This actually causes a bug on line 472 where the presentation `purpose` is replaced by any `purpose` property in the options (which is meant to be passed down to `verifyCredential` instead).