### PR TITLE
fix(credential): unify normalization of context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -540,8 +540,12 @@ export function _checkCredential({credential, now = new Date()}) {
   if(typeof now === 'string') {
     now = new Date(now);
   }
+  // normalize to an array to allow the common case of context being a string
+  const context = Array.isArray(credential['@context']) ?
+    credential['@context'] : [credential['@context']];
+
   // ensure first context is 'https://www.w3.org/2018/credentials/v1'
-  if(credential['@context'][0] !== CREDENTIALS_CONTEXT_V1_URL) {
+  if(context[0] !== CREDENTIALS_CONTEXT_V1_URL) {
     throw new Error(
       `"${CREDENTIALS_CONTEXT_V1_URL}" needs to be first in the ` +
       'list of contexts.');


### PR DESCRIPTION
In the current implementation, `@context` is only normalized for presentations and not for credentials. This PR unifies normalization so that strings are also supported.

Having said that, according to the spec `@context` must be an ordered set: https://w3c.github.io/vc-data-model/#contexts. Not sure if it's a good idea to support this any. Whatever is done, the behavior should be the same for presentations and credentials :-D