### PR TITLE
Remove node 14 ci  (require node >= 18)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/vc ChangeLog
 
+## 6.2.1 -
+
+### Fixed
+- Set `engines.node >= 18` to match requirements of dependencies.
+
 ## 6.2.0 - 2023-11-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     ]
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "JSON",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     ]
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "keywords": [
     "JSON",


### PR DESCRIPTION
Removes node 14 from the CI tests and sets node 18 as the lowest test and engine version.

p.s. node 14 is throwing this error when running the test suite:

> file:///home/runner/work/vc/vc/node_modules/@digitalbazaar/ecdsa-multikey/lib/crypto.js:4
> import {webcrypto} from 'node:crypto';
>         ^^^^^^^^^
> SyntaxError: The requested module 'node:crypto' does not provide an export named 'webcrypto'
>     at ModuleJob._instantiate (internal/modules/esm/module_job.js:124:21)
>     at async ModuleJob.run (internal/modules/esm/module_job.js:179:5)
>     at async Loader.import (internal/modules/esm/loader.js:178:24)
>     at async formattedImport (/home/runner/work/vc/vc/node_modules/mocha/lib/nodejs/esm-utils.js:9:14)
>     at async Object.exports.requireOrImport (/home/runner/work/vc/vc/node_modules/mocha/lib/nodejs/esm-utils.js:42:28)
>     at async Object.exports.loadFilesAsync (/home/runner/work/vc/vc/node_modules/mocha/lib/nodejs/esm-utils.js:[10](https://github.com/digitalbazaar/vc/actions/runs/7020090947/job/19099044737?pr=159#step:5:11)0:20)
>     at async singleRun (/home/runner/work/vc/vc/node_modules/mocha/lib/cli/run-helpers.js:[12](https://github.com/digitalbazaar/vc/actions/runs/7020090947/job/19099044737?pr=159#step:5:13)5:3)
>     at async Object.exports.handler (/home/runner/work/vc/vc/node_modules/mocha/lib/cli/run.js:370:5)


could be a duplicate of:
https://github.com/digitalbazaar/vc/pull/156/files

please note this could be a patch release as node 14 support is broken.

I am submitting this as a patch release as the current release is broken in node 14 and node 16 throws warnings on install and might have broken functionality not in the test suite.