### PR TITLE
Improve date time regex

### DIFF
--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -7,21 +7,64 @@ chai.should();
 import * as vc from '../lib/index.js';
 
 describe('verifies RFC3339 Dates', function() {
-  it('verify a valid date', function() {
+  it('should verify a valid date', function() {
     const latest = new Date().toISOString();
     vc.dateRegex.test(latest).should.be.true;
   });
-  it('verify a valid date with lowercase t', function() {
-    const latest = new Date().toISOString().toLowerCase();
-    vc.dateRegex.test(latest).should.be.true;
+  it('should verify a date with lowercase time designator', function() {
+    const valid = '2019-03-26t14:00Z';
+    vc.dateRegex.test(valid).should.be.true;
   });
-
-  it('should not verify an invalid date', function() {
+  it('should verify a date with lowercase UTC designator', function() {
+    const valid = '2019-03-26T14:00z';
+    vc.dateRegex.test(valid).should.be.true;
+  });
+  it('should not verify a date that uses / as a separator', function() {
     const invalid = '2017/09/27';
     vc.dateRegex.test(invalid).should.be.false;
   });
   it('should not verify 2 digit years', function() {
     const invalid = '17-09-27T22:07:22.563z';
     vc.dateRegex.test(invalid).should.be.false;
+  });
+  it('should not verify 1 digit months', function() {
+    const invalid = '2017-9-27T22:07:22.563z';
+    vc.dateRegex.test(invalid).should.be.false;
+  });
+  it('should verify 2 digit months starting with 0', function() {
+    const valid = '2017-09-27T22:07:22.563z';
+    vc.dateRegex.test(valid).should.be.true;
+  });
+  it('should not verify 1 digit days', function() {
+    const invalid = '2017-9-7T22:07:22.563z';
+    vc.dateRegex.test(invalid).should.be.false;
+  });
+  it('should verify 2 digit days starting with 0', function() {
+    const valid = '2017-12-07T22:07:22.563z';
+    vc.dateRegex.test(valid).should.be.true;
+  });
+  it('should not verify comma separators', function() {
+    const invalid = '2019-03-26T14:00:00,999Z';
+    vc.dateRegex.test(invalid).should.be.false;
+  });
+  it('should not verify an ISO 8601 date with hours only offset', function() {
+    const invalid = '2019-03-26T10:00-04';
+    vc.dateRegex.test(invalid).should.be.false;
+  });
+  it('should not verify an ISO 8601 date with fractional minutes', function() {
+    const invalid = '2019-03-26T14:00.9Z';
+    vc.dateRegex.test(invalid).should.be.false;
+  });
+  it('should verify leap seconds', function() {
+    const valid = '1972-06-30T23:59:60Z';
+    vc.dateRegex.test(valid).should.be.true;
+  });
+  it('should verify single digit fractional seconds', function() {
+    const valid = '2019-03-26T14:00:00.9Z';
+    vc.dateRegex.test(valid).should.be.true;
+  });
+  it('should verify multi-digit fractional seconds', function() {
+    const valid = '2019-03-26T14:00:00.4999Z';
+    vc.dateRegex.test(valid).should.be.true;
   });
 });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -22,10 +22,10 @@ describe('verifies RFC3339 Dates', function() {
       assertValid('9999-01-01T09:37:45Z');
     });
     it('should verify a date with lowercase time designator', function() {
-      assertValid('2019-03-26t14:00Z');
+      assertValid('2019-03-26t14:00:15Z');
     });
     it('should verify a date with lowercase UTC designator', function() {
-      assertValid('2019-03-26T14:00z');
+      assertValid('2019-03-26T14:00:36z');
     });
     it('should verify 2 digit months starting with 0', function() {
       assertValid('2017-09-27T22:07:22.563z');

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -61,18 +61,18 @@ describe('verifies RFC3339 Dates', function() {
         assertInvalid('2019-03-26T14:00.9Z');
       });
     it('should not verify a day greater than 31 in a month', function() {
-      assertInvalid('2017-03-45T15:00:15Z');
+      assertInvalid('2017-03-32T15:00:15Z');
     });
     it('should not verify a month greater than 12 in a year', function() {
-      assertInvalid('2017-14-22T15:00:15Z');
+      assertInvalid('2017-13-22T15:00:15Z');
     });
-    it('should not verify an hour greater than 24', function() {
-      assertInvalid('2017-10-22T25:00:15Z');
+    it('should not verify an hour greater than 23', function() {
+      assertInvalid('2017-10-22T24:00:15Z');
     });
-    it('should not verify minutes greater than 60', function() {
+    it('should not verify minutes greater than 59', function() {
       assertInvalid('2017-10-22T15:75:15Z');
     });
-    it('should not verify seconds greater than 60', function() {
+    it('should not verify seconds greater than 59', function() {
       assertInvalid('2017-10-22T15:15:65Z');
     });
     it('should not verify if no digits after decimal sign', function() {

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -6,65 +6,59 @@ chai.should();
 
 import * as vc from '../lib/index.js';
 
+const assertValid = date => vc.dateRegex.test(date).should.be.true;
+const assertInvalid = date => vc.dateRegex.test(date).should.be.false;
+
 describe('verifies RFC3339 Dates', function() {
-  it('should verify a valid date', function() {
-    const latest = new Date().toISOString();
-    vc.dateRegex.test(latest).should.be.true;
+  describe('positive', function() {
+    it('should verify a valid date', function() {
+      const latest = new Date().toISOString();
+      assertValid(latest);
+    });
+    it('should verify a date with lowercase time designator', function() {
+      assertValid('2019-03-26t14:00Z');
+    });
+    it('should verify a date with lowercase UTC designator', function() {
+      assertValid('2019-03-26T14:00z');
+    });
+    it('should verify 2 digit months starting with 0', function() {
+      assertValid('2017-09-27T22:07:22.563z');
+    });
+    it('should verify 2 digit days starting with 0', function() {
+      assertValid('2017-12-07T22:07:22.563z');
+    });
+    it('should verify leap seconds', function() {
+      assertValid('1972-06-30T23:59:60Z');
+    });
+    it('should verify single digit fractional seconds', function() {
+      assertValid('2019-03-26T14:00:00.9Z');
+    });
+    it('should verify multi-digit fractional seconds', function() {
+      assertValid('2019-03-26T14:00:00.4999Z');
+    });
   });
-  it('should verify a date with lowercase time designator', function() {
-    const valid = '2019-03-26t14:00Z';
-    vc.dateRegex.test(valid).should.be.true;
-  });
-  it('should verify a date with lowercase UTC designator', function() {
-    const valid = '2019-03-26T14:00z';
-    vc.dateRegex.test(valid).should.be.true;
-  });
-  it('should not verify a date that uses / as a separator', function() {
-    const invalid = '2017/09/27';
-    vc.dateRegex.test(invalid).should.be.false;
-  });
-  it('should not verify 2 digit years', function() {
-    const invalid = '17-09-27T22:07:22.563z';
-    vc.dateRegex.test(invalid).should.be.false;
-  });
-  it('should not verify 1 digit months', function() {
-    const invalid = '2017-9-27T22:07:22.563z';
-    vc.dateRegex.test(invalid).should.be.false;
-  });
-  it('should verify 2 digit months starting with 0', function() {
-    const valid = '2017-09-27T22:07:22.563z';
-    vc.dateRegex.test(valid).should.be.true;
-  });
-  it('should not verify 1 digit days', function() {
-    const invalid = '2017-9-7T22:07:22.563z';
-    vc.dateRegex.test(invalid).should.be.false;
-  });
-  it('should verify 2 digit days starting with 0', function() {
-    const valid = '2017-12-07T22:07:22.563z';
-    vc.dateRegex.test(valid).should.be.true;
-  });
-  it('should not verify comma separators', function() {
-    const invalid = '2019-03-26T14:00:00,999Z';
-    vc.dateRegex.test(invalid).should.be.false;
-  });
-  it('should not verify an ISO 8601 date with hours only offset', function() {
-    const invalid = '2019-03-26T10:00-04';
-    vc.dateRegex.test(invalid).should.be.false;
-  });
-  it('should not verify an ISO 8601 date with fractional minutes', function() {
-    const invalid = '2019-03-26T14:00.9Z';
-    vc.dateRegex.test(invalid).should.be.false;
-  });
-  it('should verify leap seconds', function() {
-    const valid = '1972-06-30T23:59:60Z';
-    vc.dateRegex.test(valid).should.be.true;
-  });
-  it('should verify single digit fractional seconds', function() {
-    const valid = '2019-03-26T14:00:00.9Z';
-    vc.dateRegex.test(valid).should.be.true;
-  });
-  it('should verify multi-digit fractional seconds', function() {
-    const valid = '2019-03-26T14:00:00.4999Z';
-    vc.dateRegex.test(valid).should.be.true;
+  describe('negative', function() {
+    it('should not verify a date that uses / as a separator', function() {
+      assertInvalid('2017/09/27');
+    });
+    it('should not verify 2 digit years', function() {
+      assertInvalid('17-09-27T22:07:22.563z');
+    });
+    it('should not verify 1 digit months', function() {
+      assertInvalid('2017-9-27T22:07:22.563z');
+    });
+    it('should not verify 1 digit days', function() {
+      assertInvalid('2017-9-7T22:07:22.563z');
+    });
+    it('should not verify comma separators', function() {
+      assertInvalid('2019-03-26T14:00:00,999Z');
+    });
+    it('should not verify an ISO 8601 date with hours only offset', function() {
+      assertInvalid('2019-03-26T10:00-04');
+    });
+    it('should not verify an ISO 8601 date with fractional minutes',
+      function() {
+        assertInvalid('2019-03-26T14:00.9Z');
+      });
   });
 });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -75,5 +75,8 @@ describe('verifies RFC3339 Dates', function() {
     it('should not verify seconds greater than 60', function() {
       assertInvalid('2017-10-22T15:15:65Z');
     });
+    it('should not verify if no digits after decimal sign', function() {
+      assertInvalid('2019-03-26T14:00:00.');
+    });
   });
 });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -38,7 +38,7 @@ describe('verifies RFC3339 Dates', function() {
     });
   });
   describe('negative', function() {
-    it('should not verify a date that uses / as a separator', function() {
+    it('should not verify a date that uses "/" as a separator', function() {
       assertInvalid('2017/09/27');
     });
     it('should not verify 2 digit years', function() {
@@ -60,5 +60,20 @@ describe('verifies RFC3339 Dates', function() {
       function() {
         assertInvalid('2019-03-26T14:00.9Z');
       });
+    it('should not verify a day greater than 31 in a month', function() {
+      assertInvalid('2017-03-45T15:00:15Z');
+    });
+    it('should not verify a month greater than 12 in a year', function() {
+      assertInvalid('2017-14-22T15:00:15Z');
+    });
+    it('should not verify an hour greater than 24', function() {
+      assertInvalid('2017-10-22T25:00:15Z');
+    });
+    it('should not verify minutes greater than 60', function() {
+      assertInvalid('2017-10-22T15:75:15Z');
+    });
+    it('should not verify seconds greater than 60', function() {
+      assertInvalid('2017-10-22T15:15:65Z');
+    });
   });
 });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -15,6 +15,12 @@ describe('verifies RFC3339 Dates', function() {
       const latest = new Date().toISOString();
       assertValid(latest);
     });
+    it('should verify a date with year 0000', function() {
+      assertValid('0000-01-01T09:37:45Z');
+    });
+    it('should verify a date with year 9999', function() {
+      assertValid('9999-01-01T09:37:45Z');
+    });
     it('should verify a date with lowercase time designator', function() {
       assertValid('2019-03-26t14:00Z');
     });
@@ -36,6 +42,9 @@ describe('verifies RFC3339 Dates', function() {
     it('should verify multi-digit fractional seconds', function() {
       assertValid('2019-03-26T14:00:00.4999Z');
     });
+    it('should verify leap days', function() {
+      assertValid('2024-02-29T14:00:00z');
+    });
   });
   describe('negative', function() {
     it('should not verify a date that uses "/" as a separator', function() {
@@ -44,8 +53,11 @@ describe('verifies RFC3339 Dates', function() {
     it('should not verify 2 digit years', function() {
       assertInvalid('17-09-27T22:07:22.563z');
     });
+    it('should not verify > 4 digit years', function() {
+      assertInvalid('99999-09-27T22:07:22.563z');
+    });
     it('should not verify 1 digit months', function() {
-      assertInvalid('2017-9-27T22:07:22.563z');
+      assertInvalid('2020-9-27T22:07:22.563z');
     });
     it('should not verify 1 digit days', function() {
       assertInvalid('2017-9-7T22:07:22.563z');


### PR DESCRIPTION
adds various new tests to the rfc 3339 spec

NOTE: VC 2.0 does not use the same time specification as VC 1.0