### PR TITLE
Add credentialStatus to VCs in status tests & fix assertions

### DIFF
--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -324,8 +324,23 @@ describe('verify API (credentials)', () => {
   });
 
   it('should verify a vc with a positive status check', async () => {
+    const credential = jsonld.clone(mockCredential);
+    credential['@context'].push({
+      '@context': {
+        id: '@id',
+        type: '@type',
+        TestStatusList: {
+          '@id': 'https://example.edu/TestStatusList',
+          '@type': '@id'
+        }
+      }
+    });
+    credential.credentialStatus = {
+      id: 'https://example.edu/status/24',
+      type: 'TestStatusList'
+    };
     const verifiableCredential = await vc.issue({
-      credential: mockCredential,
+      credential,
       suite,
       documentLoader
     });
@@ -422,8 +437,23 @@ describe('verify API (credentials)', () => {
       results.verified.should.be.false;
     });
     it('should fail to verify a vc with a negative status check', async () => {
+      const credential = jsonld.clone(mockCredential);
+      credential['@context'].push({
+        '@context': {
+          id: '@id',
+          type: '@type',
+          TestStatusList: {
+            '@id': 'https://example.edu/TestStatusList',
+            '@type': '@id'
+          }
+        }
+      });
+      credential.credentialStatus = {
+        id: 'https://example.edu/status/24',
+        type: 'TestStatusList'
+      };
       const verifiableCredential = await vc.issue({
-        credential: mockCredential,
+        credential,
         suite,
         documentLoader
       });
@@ -438,7 +468,7 @@ describe('verify API (credentials)', () => {
       if(result.error) {
         throw result.error;
       }
-      result.verified.should.be.true;
+      result.verified.should.be.false;
     });
     it('should fail to verify a changed derived vc', async () => {
       const proofId = `urn:uuid:${uuid()}`;

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -470,27 +470,27 @@ describe('verify API (credentials)', () => {
       }
       result.verified.should.be.false;
     });
-    it('should not run "checkStatus" on a vc without a "credentialStatus" property',
-      async () => {
-        const credential = jsonld.clone(mockCredential);
-        const verifiableCredential = await vc.issue({
-          credential,
-          suite,
-          documentLoader
-        });
-        const result = await vc.verifyCredential({
-          credential: verifiableCredential,
-          controller: assertionController,
-          suite,
-          documentLoader,
-          // ensure any checkStatus call will fail verification
-          checkStatus: async () => ({verified: false})
-        });
-        if(result.error) {
-          throw result.error;
-        }
-        result.verified.should.be.true;
+    it('should not run "checkStatus" on a vc without a ' +
+      '"credentialStatus" property', async () => {
+      const credential = jsonld.clone(mockCredential);
+      const verifiableCredential = await vc.issue({
+        credential,
+        suite,
+        documentLoader
       });
+      const result = await vc.verifyCredential({
+        credential: verifiableCredential,
+        controller: assertionController,
+        suite,
+        documentLoader,
+        // ensure any checkStatus call will fail verification
+        checkStatus: async () => ({verified: false})
+      });
+      if(result.error) {
+        throw result.error;
+      }
+      result.verified.should.be.true;
+    });
     it('should fail to verify a changed derived vc', async () => {
       const proofId = `urn:uuid:${uuid()}`;
       // setup ecdsa-sd-2023 suite for signing selective disclosure VCs

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -470,7 +470,7 @@ describe('verify API (credentials)', () => {
       }
       result.verified.should.be.false;
     });
-    it('should not run checkStatus on a vc with out a credentialStatus',
+    it('should not run "checkStatus" on a vc without a "credentialStatus" property',
       async () => {
         const credential = jsonld.clone(mockCredential);
         const verifiableCredential = await vc.issue({

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -470,6 +470,27 @@ describe('verify API (credentials)', () => {
       }
       result.verified.should.be.false;
     });
+    it('should not run checkStatus on a vc with out a credentialStatus',
+      async () => {
+        const credential = jsonld.clone(mockCredential);
+        const verifiableCredential = await vc.issue({
+          credential,
+          suite,
+          documentLoader
+        });
+        const result = await vc.verifyCredential({
+          credential: verifiableCredential,
+          controller: assertionController,
+          suite,
+          documentLoader,
+          // ensure any checkStatus call will fail verification
+          checkStatus: async () => ({verified: false})
+        });
+        if(result.error) {
+          throw result.error;
+        }
+        result.verified.should.be.true;
+      });
     it('should fail to verify a changed derived vc', async () => {
       const proofId = `urn:uuid:${uuid()}`;
       // setup ecdsa-sd-2023 suite for signing selective disclosure VCs


### PR DESCRIPTION
Changes 2 tests so they contain `credentialStatus` and then adds one test for a VC with no status.