### PR TITLE
VC 2.0 Add validUntil & validFrom / make credentialStatus.id checks optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,8 @@ jobs:
     - name: Generate coverage report
       run: npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage/lcov.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Add support for VC 2.0 Verifiable Credentials issuance and verification.
 - Add support for VC 2.0 Verifiable Presentations issuance and verification.
+- Add support for VC 2.0 `validUntil` and `validAfter`.
 - Add Test vectors for VC 2.0 VCs & VPs.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Add support for VC 2.0 Verifiable Credentials issuance and verification.
 - Add support for VC 2.0 Verifiable Presentations issuance and verification.
-- Add support for VC 2.0 `validUntil` and `validAfter`.
+- Add support for VC 2.0 `validFrom` and `validUntil`.
 - Add Test vectors for VC 2.0 VCs & VPs.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - **BREAKING**: Default issuance now uses VC 2.0 context.
+- **BREAKING**: DateTime validator is now an xml schema DateTime validator.
 
 ## 6.3.0 - 2023-xx-xx
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -49,7 +49,7 @@ export function assertCredentialContext({context}) {
 }
 
 /**
- * Throws if a Date is not correct format.
+ * Throws if a Date is not in the correct format.
  *
  * @param {object} options - Options.
  * @param {object} options.credential - A VC.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,7 +10,16 @@ export const {
     CONTEXT_URL: CREDENTIALS_CONTEXT_V2_URL
   }
 } = credentialsContextV2;
+// Z and T can be lowercase
+// RFC3339 regex
+export const dateRegex = new RegExp('^(\\d{4})-(0[1-9]|1[0-2])-' +
+    '(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):' +
+    '([0-5][0-9]):([0-5][0-9]|60)' +
+    '(\\.[0-9]+)?(Z|(\\+|-)([01][0-9]|2[0-3]):' +
+    '([0-5][0-9]))$', 'i');
 
+// entries should be in ascending version order
+// so v1 is entry 0
 const credentialContextUrls = new Set([
   CREDENTIALS_CONTEXT_V1_URL,
   CREDENTIALS_CONTEXT_V2_URL
@@ -38,6 +47,23 @@ export function assertCredentialContext({context}) {
 }
 
 /**
+ * Throws if a Date is not an RFC3339 date.
+ *
+ * @param {object} options - Options.
+ * @param {object} options.credential - A VC.
+ * @param {string} options.prop - A prop in the object.
+ *
+ * @throws {Error} Throws if the date is not a proper date string.
+ * @returns {undefined}
+ */
+export function assertDateString({credential, prop}) {
+  const value = credential[prop];
+  if(!dateRegex.test(value)) {
+    throw new Error(`"${prop}" must be a valid date: ${value}`);
+  }
+}
+
+/**
  * Turns the first context in a VC into a numbered version.
  *
  * @param {object} options - Options.
@@ -47,13 +73,7 @@ export function assertCredentialContext({context}) {
  */
 function getContextVersion({credential} = {}) {
   const firstContext = credential?.['@context']?.[0];
-  if(firstContext === CREDENTIALS_CONTEXT_V1_URL) {
-    return 1.0;
-  }
-  if(firstContext === CREDENTIALS_CONTEXT_V2_URL) {
-    return 2.0;
-  }
-  return 0;
+  return [...credentialContextUrls].indexOf(firstContext) + 1;
 }
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,13 +38,33 @@ export function assertCredentialContext({context}) {
 }
 
 /**
- * Checks to see if a VC has a V1 context.
+ * Turns the first context in a VC into a numbered version.
  *
  * @param {object} options - Options.
  * @param {object} options.credential - A VC.
  *
- * @returns {boolean} Indicates whether the VC contains a V1 context.
+ * @returns {number} A number representing the version.
  */
-export function hasV1CredentialContext({credential}) {
-  return credential?.['@context']?.[0] === CREDENTIALS_CONTEXT_V1_URL;
+function getContextVersion({credential} = {}) {
+  const firstContext = credential?.['@context']?.[0];
+  if(firstContext === CREDENTIALS_CONTEXT_V1_URL) {
+    return 1.0;
+  }
+  if(firstContext === CREDENTIALS_CONTEXT_V2_URL) {
+    return 2.0;
+  }
+  return 0;
+}
+
+/**
+ * Checks if a VC is using a specific context version.
+ *
+ * @param {object} options - Options.
+ * @param {object} options.credential - A VC.
+ * @param {number} options.version - A VC Context version
+ *
+ * @returns {boolean} If the first context matches the version.
+ */
+export function checkContextVersion({credential, version}) {
+  return getContextVersion({credential}) === version;
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -49,7 +49,7 @@ export function assertCredentialContext({context}) {
 }
 
 /**
- * Throws if a Date is not an RFC3339 date.
+ * Throws if a Date is not correct format.
  *
  * @param {object} options - Options.
  * @param {object} options.credential - A VC.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,13 +10,15 @@ export const {
     CONTEXT_URL: CREDENTIALS_CONTEXT_V2_URL
   }
 } = credentialsContextV2;
-// Z and T can be lowercase
-// RFC3339 regex
-export const dateRegex = new RegExp('^(\\d{4})-(0[1-9]|1[0-2])-' +
-    '(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):' +
-    '([0-5][0-9]):([0-5][0-9]|60)' +
-    '(\\.[0-9]+)?(Z|(\\+|-)([01][0-9]|2[0-3]):' +
-    '([0-5][0-9]))$', 'i');
+// Z and T must be uppercase
+// xml schema date time RegExp
+// @see https://www.w3.org/TR/xmlschema11-2/#dateTime
+export const dateRegex = new RegExp(
+  '-?([1-9][0-9]{3,}|0[0-9]{3})' +
+  '-(0[1-9]|1[0-2])' +
+  '-(0[1-9]|[12][0-9]|3[01])' +
+  'T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))' +
+  '(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?');
 
 // entries should be in ascending version order
 // so v1 is entry 0

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,9 +36,9 @@
  */
 import {
   assertCredentialContext,
+  checkContextVersion,
   CREDENTIALS_CONTEXT_V1_URL,
   CREDENTIALS_CONTEXT_V2_URL,
-  hasV1CredentialContext
 } from './helpers.js';
 import {documentLoader as _documentLoader} from './documentLoader.js';
 import {CredentialIssuancePurpose} from './CredentialIssuancePurpose.js';
@@ -133,7 +133,10 @@ export async function issue({
   if(!credential) {
     throw new TypeError('"credential" parameter is required for issuing.');
   }
-  if(hasV1CredentialContext({credential}) && !credential.issuanceDate) {
+  if(checkContextVersion({
+    credential,
+    version: 1.0
+  }) && !credential.issuanceDate) {
     const now = (new Date()).toJSON();
     credential.issuanceDate = `${now.slice(0, now.length - 5)}Z`;
   }
@@ -603,7 +606,8 @@ export function _checkCredential({
   if(!credential.issuer) {
     throw new Error('"issuer" property is required.');
   }
-  if(hasV1CredentialContext({credential})) {
+  if(checkContextVersion({credential, version: 1.0})) {
+    // check issued is a date
     if(!credential.issuanceDate) {
       throw new Error('"issuanceDate" property is required.');
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -612,14 +612,13 @@ export function _checkCredential({
     }
     // check if `now` is before `issuanceDate` on verification
     if(mode === 'verify') {
-      let {issuanceDate} = credential;
       assertDateString({credential, prop: 'issuanceDate'});
       // check if `now` is before `issuanceDate`
-      issuanceDate = new Date(issuanceDate);
+      const issuanceDate = new Date(credential.issuanceDate);
       if(now < issuanceDate) {
         throw new Error(
           `The current date time (${now.toISOString()}) is before the ` +
-          `"issuanceDate" (${issuanceDate.toISOString()}).`);
+          `"issuanceDate" (${credential.issuanceDate}).`);
       }
     }
   }
@@ -633,7 +632,7 @@ export function _checkCredential({
         if(now > validUntil) {
           throw new Error(
             `The current date time (${now.toISOString()}) is after ` +
-            `"validUntil" (${validUntil.toISOString()}).`);
+            `"validUntil" (${credential.validUntil}).`);
         }
       }
       if(validFrom) {
@@ -643,7 +642,7 @@ export function _checkCredential({
         if(now < validFrom) {
           throw new Error(
             `The current date time (${now.toISOString()}) is before ` +
-            `"validFrom" (${validFrom.toISOString()}).`);
+            `"validFrom" (${credential.validFrom}).`);
         }
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -635,10 +635,10 @@ export function _checkCredential({
   }
   if(checkContextVersion({credential, version: 2.0})) {
     // check if 'validUntil' and 'validFrom'
-    if(mode === 'verify') {
-      let {validUntil, validFrom} = credential;
-      if(validUntil) {
-        assertDateString({credential, prop: 'validUntil'});
+    let {validUntil, validFrom} = credential;
+    if(validUntil) {
+      assertDateString({credential, prop: 'validUntil'});
+      if(mode === 'verify') {
         validUntil = new Date(credential.validUntil);
         if(now > validUntil) {
           throw new Error(
@@ -646,9 +646,11 @@ export function _checkCredential({
             `"validUntil" (${credential.validUntil}).`);
         }
       }
-      if(validFrom) {
-        assertDateString({credential, prop: 'validFrom'});
-        // check if `now` is before `validFrom`
+    }
+    if(validFrom) {
+      assertDateString({credential, prop: 'validFrom'});
+      if(mode === 'verify') {
+      // check if `now` is before `validFrom`
         validFrom = new Date(credential.validFrom);
         if(now < validFrom) {
           throw new Error(

--- a/lib/index.js
+++ b/lib/index.js
@@ -601,7 +601,7 @@ export function _checkCredential({
     throw new Error('"issuer" property is required.');
   }
   if(checkContextVersion({credential, version: 1.0})) {
-    // check issued is a date
+    // check issuanceDate exists
     if(!credential.issuanceDate) {
       throw new Error('"issuanceDate" property is required.');
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -632,7 +632,7 @@ export function _checkCredential({
         validUntil = new Date(credential.validUntil);
         if(now > validUntil) {
           throw new Error(
-            `The current date time (${now.toISOString()}) is after the ` +
+            `The current date time (${now.toISOString()}) is after ` +
             `"validUntil" (${validUntil.toISOString()}).`);
         }
       }
@@ -642,7 +642,7 @@ export function _checkCredential({
         validFrom = new Date(credential.validFrom);
         if(now < validFrom) {
           throw new Error(
-            `The current date time (${now.toISOString()}) is before the ` +
+            `The current date time (${now.toISOString()}) is before ` +
             `"validFrom" (${validFrom.toISOString()}).`);
         }
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -674,17 +674,18 @@ export function _checkCredential({
     _validateUriId({id: issuer, propertyName: 'issuer'});
   }
 
-  if('credentialStatus' in credential) {
-    const {credentialStatus} = credential;
-    if(Array.isArray(credentialStatus) ?
-      credentialStatus.some(cs => !cs.id) : !credentialStatus.id) {
-      throw new Error('"credentialStatus" must include an id.');
+  // check credentialStatus
+  jsonld.getValues(credential, 'credentialStatus').forEach(cs => {
+    // check if optional "id" is a URL
+    if('id' in cs) {
+      _validateUriId({id: cs.id, propertyName: 'credentialStatus.id'});
     }
-    if(Array.isArray(credentialStatus) ?
-      credentialStatus.some(cs => !cs.type) : !credentialStatus.type) {
+
+    // check "type" present
+    if(!cs.type) {
       throw new Error('"credentialStatus" must include a type.');
     }
-  }
+  });
 
   // check evidences are URLs
   jsonld.getValues(credential, 'evidence').forEach(evidence => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -605,13 +605,13 @@ export function _checkCredential({
     if(!credential.issuanceDate) {
       throw new Error('"issuanceDate" property is required.');
     }
+    // check issuanceDate format on issue
+    assertDateString({credential, prop: 'issuanceDate'});
 
     // check issuanceDate cardinality
     if(jsonld.getValues(credential, 'issuanceDate').length > 1) {
       throw new Error('"issuanceDate" property can only have one value.');
     }
-    // check issuanceDate format on issue
-    assertDateString({credential, prop: 'issuanceDate'});
     // optionally check expirationDate
     if('expirationDate' in credential) {
       // check if `expirationDate` property is a date

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@
  */
 import {
   assertCredentialContext,
+  assertDateString,
   checkContextVersion,
   CREDENTIALS_CONTEXT_V1_URL,
   CREDENTIALS_CONTEXT_V2_URL,
@@ -46,16 +47,9 @@ import jsigs from 'jsonld-signatures';
 import jsonld from 'jsonld';
 
 const {AssertionProofPurpose, AuthenticationProofPurpose} = jsigs.purposes;
-
+export {dateRegex} from './helpers.js';
 export const defaultDocumentLoader = jsigs.extendContextLoader(_documentLoader);
 export {CredentialIssuancePurpose};
-// Z and T can be lowercase
-// RFC3339 regex
-export const dateRegex = new RegExp('^(\\d{4})-(0[1-9]|1[0-2])-' +
-    '(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):' +
-    '([0-5][0-9]):([0-5][0-9]|60)' +
-    '(\\.[0-9]+)?(Z|(\\+|-)([01][0-9]|2[0-3]):' +
-    '([0-5][0-9]))$', 'i');
 
 /**
  * @typedef {object} LinkedDataSignature
@@ -619,15 +613,38 @@ export function _checkCredential({
     // check if `now` is before `issuanceDate` on verification
     if(mode === 'verify') {
       let {issuanceDate} = credential;
-      if(!dateRegex.test(issuanceDate)) {
-        throw new Error(`"issuanceDate" must be a valid date: ${issuanceDate}`);
-      }
+      assertDateString({credential, prop: 'issuanceDate'});
       // check if `now` is before `issuanceDate`
       issuanceDate = new Date(issuanceDate);
       if(now < issuanceDate) {
         throw new Error(
           `The current date time (${now.toISOString()}) is before the ` +
           `"issuanceDate" (${issuanceDate.toISOString()}).`);
+      }
+    }
+  }
+  if(checkContextVersion({credential, version: 2.0})) {
+    // check if 'validUntil' and 'validFrom'
+    if(mode === 'verify') {
+      let {validUntil, validFrom} = credential;
+      if(validUntil) {
+        assertDateString({credential, prop: 'validUntil'});
+        validUntil = new Date(credential.validUntil);
+        if(now > validUntil) {
+          throw new Error(
+            `The current date time (${now.toISOString()}) is after the ` +
+            `"validUntil" (${validUntil.toISOString()}).`);
+        }
+      }
+      if(validFrom) {
+        assertDateString({credential, prop: 'validFrom'});
+        // check if `now` is before `validFrom`
+        validFrom = new Date(credential.validFrom);
+        if(now < validFrom) {
+          throw new Error(
+            `The current date time (${now.toISOString()}) is before the ` +
+            `"validFrom" (${validFrom.toISOString()}).`);
+        }
       }
     }
   }
@@ -668,10 +685,7 @@ export function _checkCredential({
   if('expirationDate' in credential) {
     const {expirationDate} = credential;
     // check if `expirationDate` property is a date
-    if(!dateRegex.test(expirationDate)) {
-      throw new Error(
-        `"expirationDate" must be a valid date: ${expirationDate}`);
-    }
+    assertDateString({credential, prop: 'expirationDate'});
     // check if `now` is after `expirationDate`
     if(now > new Date(expirationDate)) {
       throw new Error('Credential has expired.');

--- a/lib/index.js
+++ b/lib/index.js
@@ -610,10 +610,21 @@ export function _checkCredential({
     if(jsonld.getValues(credential, 'issuanceDate').length > 1) {
       throw new Error('"issuanceDate" property can only have one value.');
     }
+    // check issuanceDate format on issue
+    assertDateString({credential, prop: 'issuanceDate'});
+    // optionally check expirationDate
+    if('expirationDate' in credential) {
+      // check if `expirationDate` property is a date
+      assertDateString({credential, prop: 'expirationDate'});
+      if(mode === 'verify') {
+        // check if `now` is after `expirationDate`
+        if(now > new Date(credential.expirationDate)) {
+          throw new Error('Credential has expired.');
+        }
+      }
+    }
     // check if `now` is before `issuanceDate` on verification
     if(mode === 'verify') {
-      assertDateString({credential, prop: 'issuanceDate'});
-      // check if `now` is before `issuanceDate`
       const issuanceDate = new Date(credential.issuanceDate);
       if(now < issuanceDate) {
         throw new Error(
@@ -681,15 +692,6 @@ export function _checkCredential({
     }
   });
 
-  if('expirationDate' in credential) {
-    const {expirationDate} = credential;
-    // check if `expirationDate` property is a date
-    assertDateString({credential, prop: 'expirationDate'});
-    // check if `now` is after `expirationDate`
-    if(now > new Date(expirationDate)) {
-      throw new Error('Credential has expired.');
-    }
-  }
   // check if properties that require a type are
   // defined, objects, and objects with types
   for(const prop of mustHaveType) {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1034,14 +1034,18 @@ for(const [version, mockCredential] of versionedCredentials) {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validFrom = createSkewedTimeStamp({skewYear: 1});
+          const now = new Date();
           let error;
           try {
-            vc._checkCredential({credential});
+            vc._checkCredential({credential, now});
           } catch(e) {
             error = e;
           }
           should.exist(error,
             'Should throw error when "validFrom" in future');
+          error.message.should.contain(
+            `The current date time (${now.toISOString()}) is before ` +
+            `"validFrom" (${credential.validFrom})`);
         });
         it('should accept "validFrom" in the past', () => {
           const credential = mockCredential();
@@ -1060,14 +1064,18 @@ for(const [version, mockCredential] of versionedCredentials) {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validUntil = createSkewedTimeStamp({skewYear: -1});
+          const now = new Date();
           let error;
           try {
-            vc._checkCredential({credential});
+            vc._checkCredential({credential, now});
           } catch(e) {
             error = e;
           }
           should.exist(error,
             'Should throw error when "validUntil" in the past');
+          error.message.should.contain(
+            `The current date time (${now.toISOString()}) is after ` +
+            `"validUntil" (${credential.validUntil})`);
         });
         it('should accept "validUntil" in the future', () => {
           const credential = mockCredential();
@@ -1117,20 +1125,25 @@ for(const [version, mockCredential] of versionedCredentials) {
           credential.issuer = 'did:example:12345';
           credential.validFrom = createSkewedTimeStamp({skewYear: -2});
           credential.validUntil = createSkewedTimeStamp({skewYear: -1});
+          const now = new Date();
           let error;
           try {
-            vc._checkCredential({credential});
+            vc._checkCredential({credential, now});
           } catch(e) {
             error = e;
           }
           should.exist(error,
             'Should throw when now is after "validFrom" & "validUntil"');
+          error.message.should.contain(
+            `The current date time (${now.toISOString()}) is after ` +
+            `"validUntil" (${credential.validUntil}).`);
         });
         it('should reject if now is before "validFrom" & "validUntil"', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validFrom = createSkewedTimeStamp({skewYear: 1});
           credential.validUntil = createSkewedTimeStamp({skewYear: 2});
+          const now = new Date();
           let error;
           try {
             vc._checkCredential({credential});
@@ -1139,6 +1152,10 @@ for(const [version, mockCredential] of versionedCredentials) {
           }
           should.exist(error,
             'Should throw when now is before "validFrom" & "validUntil"');
+          error.message.should.contain(
+            `The current date time (${now.toISOString()}) is before ` +
+            `"validFrom" (${credential.validFrom}).`
+          );
         });
       }
       it('should reject if "credentialSubject" is empty', () => {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -14,6 +14,7 @@ import {
 } from './testDocumentLoader.js';
 import {assertionController} from './mocks/assertionController.js';
 import chai from 'chai';
+import {createTimeStamp} from './helpers.js';
 import {CredentialIssuancePurpose} from '../lib/CredentialIssuancePurpose.js';
 import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import {Ed25519Signature2018} from '@digitalbazaar/ed25519-signature-2018';
@@ -202,14 +203,16 @@ for(const [version, mockCredential] of versionedCredentials) {
         it('should issue "validUntil" in the future', async () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
-          credential.validUntil = '2025-10-31T19:21:25Z';
-          const now = '2022-06-30T19:21:25Z';
+          const validUntil = new Date();
+          // set validUntil one year in the future
+          validUntil.setFullYear(validUntil.getFullYear() + 1);
+          // turn it into an ISO Time Stamp
+          credential.validUntil = createTimeStamp({date: validUntil});
           let error;
           let verifiableCredential;
           try {
             verifiableCredential = await vc.issue({
               credential,
-              now,
               suite,
               documentLoader
             });
@@ -231,14 +234,16 @@ for(const [version, mockCredential] of versionedCredentials) {
         it('should issue "validUntil" in the past', async () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
-          credential.validUntil = '2022-10-31T19:21:25Z';
-          const now = '2025-06-30T19:21:25Z';
+          const validUntil = new Date();
+          // set validUntil one year in the past
+          validUntil.setFullYear(validUntil.getFullYear() - 1);
+          // turn it into an ISO Time Stamp
+          credential.validUntil = createTimeStamp({date: validUntil});
           let error;
           let verifiableCredential;
           try {
             verifiableCredential = await vc.issue({
               credential,
-              now,
               suite,
               documentLoader
             });
@@ -260,14 +265,14 @@ for(const [version, mockCredential] of versionedCredentials) {
         it('should issue "validFrom" in the past', async () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
-          credential.validFrom = '2022-06-30T19:21:25Z';
-          const now = '2022-10-30T19:21:25Z';
+          const validFrom = new Date();
+          validFrom.setFullYear(validFrom.getFullYear() - 1);
+          credential.validFrom = createTimeStamp({date: validFrom});
           let error;
           let verifiableCredential;
           try {
             verifiableCredential = await vc.issue({
               credential,
-              now,
               suite,
               documentLoader
             });
@@ -289,14 +294,14 @@ for(const [version, mockCredential] of versionedCredentials) {
         it('should issue "validFrom" in the future', async () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
-          credential.validFrom = '2022-10-30T19:21:25Z';
-          const now = '2022-06-30T19:21:25Z';
+          const validFrom = new Date();
+          validFrom.setFullYear(validFrom.getFullYear() + 1);
+          credential.validFrom = createTimeStamp({date: validFrom});
           let error;
           let verifiableCredential;
           try {
             verifiableCredential = await vc.issue({
               credential,
-              now,
               suite,
               documentLoader
             });
@@ -318,17 +323,19 @@ for(const [version, mockCredential] of versionedCredentials) {
         it('should issue both "validFrom" and "validUntil"', async () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
-          credential.validFrom = '2022-05-30T19:21:25Z';
-          credential.validUntil = '2025-05-30T19:21:25Z';
-          const now = '2022-06-30T19:21:25Z';
+          const validFrom = new Date();
+          validFrom.setFullYear(validFrom.getFullYear() - 1);
+          credential.validFrom = createTimeStamp({date: validFrom});
+          const validUntil = new Date();
+          validUntil.setFullYear(validFrom.getFullYear() + 1);
+          credential.validUntil = createTimeStamp({date: validUntil});
           let error;
           let verifiableCredential;
           try {
             verifiableCredential = await vc.issue({
               credential,
               suite,
-              documentLoader,
-              now
+              documentLoader
             });
           } catch(e) {
             error = e;

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1011,7 +1011,6 @@ for(const [version, mockCredential] of versionedCredentials) {
       if(version === 1.0) {
         // we submit with second precission,
         // but throw with millisecond precision
-        const getISOString = stamp => new Date(stamp).toISOString();
         it('should reject if "now" is before "issuanceDate"', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
@@ -1026,8 +1025,8 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.exist(error,
             'Should throw error when "now" is before "issuanceDate"');
           error.message.should.contain(
-            `The current date time (${getISOString(now)}) is before the ` +
-            `"issuanceDate" (${getISOString(credential.issuanceDate)}).`);
+            `The current date time (${now}) is before the ` +
+            `"issuanceDate" (${credential.issuanceDate}).`);
         });
       }
       if(version === 2.0) {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -972,6 +972,40 @@ for(const [version, mockCredential] of versionedCredentials) {
           .contain('"issuer" must be a URI');
       });
 
+      it('should reject credentialStatus that is not a URI', () => {
+        const credential = mockCredential();
+        credential.credentialStatus = {
+          id: 'not-a-url',
+          type: 'urn:type'
+        };
+        let error;
+        try {
+          vc._checkCredential({credential});
+        } catch(e) {
+          error = e;
+        }
+        should.exist(error,
+          'Should throw error when "evidence" is not a URI');
+        error.should.be.instanceof(TypeError);
+        error.message.should
+          .contain('"credentialStatus.id" must be a URI');
+      });
+
+      it('should accept "credentialStatus" with no "id"', () => {
+        const credential = mockCredential();
+        credential.credentialStatus = {
+          type: 'urn:type'
+        };
+        let error;
+        try {
+          vc._checkCredential({credential});
+        } catch(e) {
+          error = e;
+        }
+        should.not.exist(error,
+          'Should not throw error when "credentialStatus.id" is absent');
+      });
+
       it('should reject an evidence id that is not a URI', () => {
         const credential = mockCredential();
         credential.issuer = 'did:example:12345';

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1106,7 +1106,7 @@ for(const [version, mockCredential] of versionedCredentials) {
         });
         it('should accept if "validFrom" & "validUntil" are the same time',
           () => {
-            const credential = jsonld.clone(mockCredential);
+            const credential = mockCredential();
             credential.issuer = 'did:example:12345';
             const now = createSkewedTimeStamp({skewYear: 0});
             credential.validFrom = now;

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -23,8 +23,6 @@ import {
 } from '@digitalbazaar/ed25519-verification-key-2018';
 import {invalidContexts} from './contexts/index.js';
 import jsigs from 'jsonld-signatures';
-import {klona} from 'klona';
-import {mock as mockData} from './mocks/mock.data.js';
 import {v4 as uuid} from 'uuid';
 import {VeresOneDriver} from 'did-veres-one';
 import {versionedCredentials} from './mocks/credential.js';
@@ -943,7 +941,7 @@ for(const [version, mockCredential] of versionedCredentials) {
 
     describe('_checkCredential', () => {
       it('should reject a credentialSubject.id that is not a URI', () => {
-        const credential = klona(mockData.credentials.alpha);
+        const credential = mockCredential();
         credential.issuer = 'http://example.edu/credentials/58473';
         credential.credentialSubject.id = '12345';
         let error;
@@ -960,7 +958,7 @@ for(const [version, mockCredential] of versionedCredentials) {
       });
 
       it('should reject an issuer that is not a URI', () => {
-        const credential = klona(mockData.credentials.alpha);
+        const credential = mockCredential();
         credential.issuer = '12345';
         let error;
         try {
@@ -976,7 +974,7 @@ for(const [version, mockCredential] of versionedCredentials) {
       });
 
       it('should reject an evidence id that is not a URI', () => {
-        const credential = klona(mockData.credentials.alpha);
+        const credential = mockCredential();
         credential.issuer = 'did:example:12345';
         credential.evidence = '12345';
         let error;
@@ -992,25 +990,23 @@ for(const [version, mockCredential] of versionedCredentials) {
           .contain('"evidence" must be a URI');
       });
 
-      it('should reject if "expirationDate" has passed', () => {
-        const credential = klona(mockData.credentials.alpha);
-        credential.issuer = 'did:example:12345';
-        // set expirationDate to an expired date.
-        credential.expirationDate = '2020-05-31T19:21:25Z';
-        let error;
-        try {
-          vc._checkCredential({credential});
-        } catch(e) {
-          error = e;
-        }
-        should.exist(error,
-          'Should throw error when "expirationDate" has passed');
-        error.message.should
-          .contain('Credential has expired.');
-      });
       if(version === 1.0) {
-        // we submit with second precission,
-        // but throw with millisecond precision
+        it('should reject if "expirationDate" has passed', () => {
+          const credential = mockCredential();
+          credential.issuer = 'did:example:12345';
+          // set expirationDate to an expired date.
+          credential.expirationDate = '2020-05-31T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, mode: 'verify'});
+          } catch(e) {
+            error = e;
+          }
+          should.exist(error,
+            'Should throw error when "expirationDate" has passed');
+          error.message.should
+            .contain('Credential has expired.');
+        });
         it('should reject if "now" is before "issuanceDate"', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -332,7 +332,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           verifiableCredential.should.be.an('object');
           verifiableCredential.should.have.property('proof');
           verifiableCredential.proof.should.be.an('object');
-          // ensure validUntil & validAfter are present
+          // ensure validFrom & validUntil are present
           // and have correct timestamps
           verifiableCredential.should.have.property(
             'validFrom',

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1073,11 +1073,8 @@ for(const [version, mockCredential] of versionedCredentials) {
           } catch(e) {
             error = e;
           }
-          should.exist(error,
-            'Should throw error when "now" is before "issuanceDate"');
-          error.message.should.contain(
-            'The current date time (2022-06-30T19:21:25.000Z) is before the ' +
-            '"issuanceDate" (2022-10-31T19:21:25.000Z).');
+          should.not.exist(error,
+            'Should NOT throw when now is between "validFrom" & "validUntil"');
         });
       }
       it('should reject if "credentialSubject" is empty', () => {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1136,7 +1136,6 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.exist(error,
             'Should throw when now is before "validFrom" & "validUntil"');
         });
-
       }
       it('should reject if "credentialSubject" is empty', () => {
         const credential = mockCredential();

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1049,7 +1049,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.exist(error,
             'Should throw error when verifying "validFrom" in future');
         });
-        it('should reject "validFrom" in the past', () => {
+        it('should accept "validFrom" in the past', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validFrom = '2022-06-30T19:21:25Z';
@@ -1077,7 +1077,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.exist(error,
             'Should throw error when "validUntil" in the past');
         });
-        it('should reject "validUntil" in the future', () => {
+        it('should accept "validUntil" in the future', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validUntil = '2025-10-31T19:21:25Z';

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1005,7 +1005,7 @@ for(const [version, mockCredential] of versionedCredentials) {
         });
       }
       if(version === 2.0) {
-        it('should NOT verify "validFrom" in the future', () => {
+        it('should reject "validFrom" in the future', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validFrom = '2022-10-30T19:21:25Z';
@@ -1019,7 +1019,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.exist(error,
             'Should throw error when verifying "validFrom" in future');
         });
-        it('should verify "validFrom" in the past', () => {
+        it('should reject "validFrom" in the past', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validFrom = '2022-06-30T19:21:25Z';
@@ -1033,7 +1033,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.not.exist(error,
             'Should not throw error when "validFrom" in past');
         });
-        it('should NOT verify if "validUntil" in the past', () => {
+        it('should reject "validUntil" in the past', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validUntil = '2022-06-31T19:21:25Z';
@@ -1047,7 +1047,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.exist(error,
             'Should throw error when "validUntil" in the past');
         });
-        it('should verify if "validUntil" in the future', () => {
+        it('should reject "validUntil" in the future', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validUntil = '2025-10-31T19:21:25Z';
@@ -1061,7 +1061,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.not.exist(error,
             'Should not throw error when "issuanceDate" is valid');
         });
-        it('should verify if "validFrom" is before "validUntil"', () => {
+        it('should accept if now is between "validFrom" & "validUntil"', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.validFrom = '2022-05-30T19:21:25Z';
@@ -1076,6 +1076,37 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.not.exist(error,
             'Should NOT throw when now is between "validFrom" & "validUntil"');
         });
+        it('should reject if now is after "validFrom" & "validUntil"', () => {
+          const credential = mockCredential();
+          credential.issuer = 'did:example:12345';
+          credential.validFrom = '2022-05-30T19:21:25Z';
+          credential.validUntil = '2023-05-30T19:21:25Z';
+          const now = '2024-06-30T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.exist(error,
+            'Should throw when now is after "validFrom" & "validUntil"');
+        });
+        it('should reject if now is before "validFrom" & "validUntil"', () => {
+          const credential = mockCredential();
+          credential.issuer = 'did:example:12345';
+          credential.validFrom = '2024-05-30T19:21:25Z';
+          credential.validUntil = '2025-05-30T19:21:25Z';
+          const now = '2023-06-30T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.exist(error,
+            'Should throw when now is before "validFrom" & "validUntil"');
+        });
+
       }
       it('should reject if "credentialSubject" is empty', () => {
         const credential = mockCredential();

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -198,61 +198,101 @@ for(const [version, mockCredential] of versionedCredentials) {
           .contain('"suite.verificationMethod" property is required.');
       });
       if(version === 2.0) {
-        it('should issue "validUntil" in the future', () => {
+        it('should issue "validUntil" in the future', async () => {
           const credential = jsonld.clone(mockCredential);
           credential.issuer = 'did:example:12345';
           credential.validUntil = '2025-10-31T19:21:25Z';
           const now = '2022-06-30T19:21:25Z';
           let error;
+          let result;
           try {
-            vc.issue({credential, now});
+            result = await vc.issue({
+              credential,
+              now,
+              suite,
+              documentLoader
+            });
           } catch(e) {
             error = e;
           }
           should.not.exist(error,
             'Should not throw error when issuing "validUntil" in future');
+          should.exist(
+            result,
+            'Expected a VC with "validUntil" in the future to be issued'
+          );
         });
-        it('should issue "validUntil" in the past', () => {
+        it('should issue "validUntil" in the past', async () => {
           const credential = jsonld.clone(mockCredential);
           credential.issuer = 'did:example:12345';
           credential.validUntil = '2025-10-31T19:21:25Z';
           const now = '2022-06-30T19:21:25Z';
           let error;
+          let result;
           try {
-            vc.issue({credential, now});
+            result = await vc.issue({
+              credential,
+              now,
+              suite,
+              documentLoader
+            });
           } catch(e) {
             error = e;
           }
           should.not.exist(error,
             'Should not throw error when issuing with "validUntil" in past');
+          should.exist(
+            result,
+            'Expected a VC with "validUntil" in the past to be issued'
+          );
         });
-        it('should issue "validFrom" in the past', () => {
+        it('should issue "validFrom" in the past', async () => {
           const credential = jsonld.clone(mockCredential);
           credential.issuer = 'did:example:12345';
           credential.validFrom = '2022-06-30T19:21:25Z';
           const now = '2022-10-30T19:21:25Z';
           let error;
+          let result;
           try {
-            vc.issue({credential, now});
+            result = await vc.issue({
+              credential,
+              now,
+              suite,
+              documentLoader
+            });
           } catch(e) {
             error = e;
           }
           should.not.exist(error,
             'Should not throw error when issuing "validFrom" in past');
+          should.exist(
+            result,
+            'Expected a VC with "validFrom" in the past to be issued'
+          );
         });
-        it('should issue "validFrom" in the future', () => {
+        it('should issue "validFrom" in the future', async () => {
           const credential = jsonld.clone(mockCredential);
           credential.issuer = 'did:example:12345';
           credential.validFrom = '2022-10-30T19:21:25Z';
           const now = '2022-06-30T19:21:25Z';
           let error;
+          let result;
           try {
-            vc.issue({credential, now});
+            result = await vc.issue({
+              credential,
+              now,
+              suite,
+              documentLoader
+            });
           } catch(e) {
             error = e;
           }
           should.not.exist(error,
             'Should not throw error when issuing "validFrom" in future');
+          should.exist(
+            result,
+            'Expected a VC with "validFrom" in the future to be issued'
+          );
         });
       }
     });

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -876,7 +876,89 @@ for(const [version, mockCredential] of versionedCredentials) {
             'The current date time (2022-06-30T19:21:25.000Z) is before the ' +
             '"issuanceDate" (2022-10-31T19:21:25.000Z).');
         });
+      }
+      if(version === 2.0) {
+        it('should reject if "now" is before "validFrom"', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validFrom = '2022-10-31T19:21:25Z';
+          const now = '2022-06-30T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.exist(error,
+            'Should throw error when "now" is before "validFrom"');
+          error.message.should.contain(
+            `The current date time (${now}) is before the ` +
+            `"validFrom" (${credential.validFrom}).`);
+        });
+        it('should reject if "now" is after "validUntil"', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validUntil = '2022-06-30T19:21:25Z';
+          const now = '2022-10-30T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.exist(error,
+            'Should throw error when "now" is after "validUntil"');
+          error.message.should.contain(
+            `The current date time (${now}) is after the ` +
+            `"validUntil" (${credential.validUntil}).`);
+        });
+        it('should accept "validFrom"', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validFrom = '2022-06-30T19:21:25Z';
+          const now = '2022-10-30T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(error,
+            'Should not throw error when "validFrom" is valid');
+        });
+        it('should accept "validUntil"', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validUntil = '2025-10-31T19:21:25Z';
+          const now = '2022-06-30T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(error,
+            'Should not throw error when "issuanceDate" is valid');
+        });
 
+        it('should accept both "validFrom" and "validUntil" are valid', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validFrom = '2022-05-30T19:21:25Z';
+          credential.validUntil = '2025-05-30T19:21:25Z';
+          const now = '2022-06-30T19:21:25Z';
+          let error;
+          try {
+            vc._checkCredential({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.exist(error,
+            'Should throw error when "now" is before "issuanceDate"');
+          error.message.should.contain(
+            'The current date time (2022-06-30T19:21:25.000Z) is before the ' +
+            '"issuanceDate" (2022-10-31T19:21:25.000Z).');
+        });
       }
       it('should reject if "credentialSubject" is empty', () => {
         const credential = mockCredential();

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1119,7 +1119,7 @@ for(const [version, mockCredential] of versionedCredentials) {
             } catch(e) {
               error = e;
             }
-            should.not.exist(error, 'Should NOT throw when now is between' +
+            should.not.exist(error, 'Should NOT throw when now equals' +
             '"validFrom" & "validUntil"');
           });
         it('should reject if now is after "validFrom" & "validUntil"', () => {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -144,7 +144,7 @@ for(const [version, mockCredential] of versionedCredentials) {
         }
 
         should.exist(error,
-          'Should throw error when "verificationMethod" property missing');
+          'Should throw error when "verificationMethod" property is missing');
         error.should.be.instanceof(TypeError);
         error.message.should
           .contain('"suite.verificationMethod" property is required.');

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -141,7 +141,6 @@ for(const [version, mockCredential] of versionedCredentials) {
         } catch(e) {
           error = e;
         }
-
         should.exist(error,
           'Should throw error when "verificationMethod" property is missing');
         error.should.be.instanceof(TypeError);

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1089,7 +1089,7 @@ for(const [version, mockCredential] of versionedCredentials) {
             error = e;
           }
           should.not.exist(error,
-            'Should not throw error when "issuanceDate" is valid');
+            'Should not throw error when "validUntil" in the future');
         });
         it('should accept if now is between "validFrom" & "validUntil"', () => {
           const credential = mockCredential();

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1106,6 +1106,22 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.not.exist(error,
             'Should NOT throw when now is between "validFrom" & "validUntil"');
         });
+        it('should accept if "validFrom" & "validUntil" are the same time',
+          () => {
+            const credential = jsonld.clone(mockCredential);
+            credential.issuer = 'did:example:12345';
+            const now = '2022-06-30T19:21:25Z';
+            credential.validFrom = now;
+            credential.validUntil = now;
+            let error;
+            try {
+              vc._checkCredential({credential, now});
+            } catch(e) {
+              error = e;
+            }
+            should.not.exist(error, 'Should NOT throw when now is between' +
+            '"validFrom" & "validUntil"');
+          });
         it('should reject if now is after "validFrom" & "validUntil"', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1015,7 +1015,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
           credential.issuanceDate = createSkewedTimeStamp({skewYear: 1});
-          const now = createSkewedTimeStamp({skewYear: 0});
+          const now = new Date();
           let error;
           try {
             vc._checkCredential({credential, now});
@@ -1025,7 +1025,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           should.exist(error,
             'Should throw error when "now" is before "issuanceDate"');
           error.message.should.contain(
-            `The current date time (${now}) is before the ` +
+            `The current date time (${now.toISOString()}) is before the ` +
             `"issuanceDate" (${credential.issuanceDate}).`);
         });
       }

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -972,7 +972,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           .contain('"issuer" must be a URI');
       });
 
-      it('should reject credentialStatus that is not a URI', () => {
+      it('should reject credentialStatus id that is not a URI', () => {
         const credential = mockCredential();
         credential.credentialStatus = {
           id: 'not-a-url',
@@ -985,7 +985,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           error = e;
         }
         should.exist(error,
-          'Should throw error when "evidence" is not a URI');
+          'Should throw error when "credentialStatus.id" is not a URI');
         error.should.be.instanceof(TypeError);
         error.message.should
           .contain('"credentialStatus.id" must be a URI');

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -6,6 +6,7 @@ import * as Bls12381Multikey from '@digitalbazaar/bls12-381-multikey';
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';
 import * as ecdsaSd2023Cryptosuite from
   '@digitalbazaar/ecdsa-sd-2023-cryptosuite';
+import * as mockData from './mocks/mock.data.js';
 import * as vc from '../lib/index.js';
 import {
   documentLoader,

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1047,7 +1047,7 @@ for(const [version, mockCredential] of versionedCredentials) {
             error = e;
           }
           should.exist(error,
-            'Should throw error when verifying "validFrom" in future');
+            'Should throw error when "validFrom" in future');
         });
         it('should accept "validFrom" in the past', () => {
           const credential = mockCredential();

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -205,9 +205,9 @@ for(const [version, mockCredential] of versionedCredentials) {
           credential.validUntil = '2025-10-31T19:21:25Z';
           const now = '2022-06-30T19:21:25Z';
           let error;
-          let result;
+          let verifiableCredential;
           try {
-            result = await vc.issue({
+            verifiableCredential = await vc.issue({
               credential,
               now,
               suite,
@@ -218,9 +218,14 @@ for(const [version, mockCredential] of versionedCredentials) {
           }
           should.not.exist(error,
             'Should not throw error when issuing "validUntil" in future');
-          should.exist(
-            result,
-            'Expected a VC with "validUntil" in the future to be issued'
+          verifiableCredential.should.exist;
+          verifiableCredential.should.be.an('object');
+          verifiableCredential.should.have.property('proof');
+          verifiableCredential.proof.should.be.an('object');
+          // ensure validUntil is present and has correct timestamp
+          verifiableCredential.should.have.property(
+            'validUntil',
+            credential.validUntil
           );
         });
         it('should issue "validUntil" in the past', async () => {
@@ -229,9 +234,9 @@ for(const [version, mockCredential] of versionedCredentials) {
           credential.validUntil = '2022-10-31T19:21:25Z';
           const now = '2025-06-30T19:21:25Z';
           let error;
-          let result;
+          let verifiableCredential;
           try {
-            result = await vc.issue({
+            verifiableCredential = await vc.issue({
               credential,
               now,
               suite,
@@ -242,9 +247,14 @@ for(const [version, mockCredential] of versionedCredentials) {
           }
           should.not.exist(error,
             'Should not throw error when issuing with "validUntil" in past');
-          should.exist(
-            result,
-            'Expected a VC with "validUntil" in the past to be issued'
+          verifiableCredential.should.exist;
+          verifiableCredential.should.be.an('object');
+          verifiableCredential.should.have.property('proof');
+          verifiableCredential.proof.should.be.an('object');
+          // ensure validUntil is present and has correct timestamp
+          verifiableCredential.should.have.property(
+            'validUntil',
+            credential.validUntil
           );
         });
         it('should issue "validFrom" in the past', async () => {
@@ -253,9 +263,9 @@ for(const [version, mockCredential] of versionedCredentials) {
           credential.validFrom = '2022-06-30T19:21:25Z';
           const now = '2022-10-30T19:21:25Z';
           let error;
-          let result;
+          let verifiableCredential;
           try {
-            result = await vc.issue({
+            verifiableCredential = await vc.issue({
               credential,
               now,
               suite,
@@ -266,9 +276,14 @@ for(const [version, mockCredential] of versionedCredentials) {
           }
           should.not.exist(error,
             'Should not throw error when issuing "validFrom" in past');
-          should.exist(
-            result,
-            'Expected a VC with "validFrom" in the past to be issued'
+          verifiableCredential.should.exist;
+          verifiableCredential.should.be.an('object');
+          verifiableCredential.should.have.property('proof');
+          verifiableCredential.proof.should.be.an('object');
+          // ensure validFrom is present and has correct timestamp
+          verifiableCredential.should.have.property(
+            'validFrom',
+            credential.validFrom
           );
         });
         it('should issue "validFrom" in the future', async () => {
@@ -277,9 +292,9 @@ for(const [version, mockCredential] of versionedCredentials) {
           credential.validFrom = '2022-10-30T19:21:25Z';
           const now = '2022-06-30T19:21:25Z';
           let error;
-          let result;
+          let verifiableCredential;
           try {
-            result = await vc.issue({
+            verifiableCredential = await vc.issue({
               credential,
               now,
               suite,
@@ -290,9 +305,14 @@ for(const [version, mockCredential] of versionedCredentials) {
           }
           should.not.exist(error,
             'Should not throw error when issuing "validFrom" in future');
-          should.exist(
-            result,
-            'Expected a VC with "validFrom" in the future to be issued'
+          verifiableCredential.should.exist;
+          verifiableCredential.should.be.an('object');
+          verifiableCredential.should.have.property('proof');
+          verifiableCredential.proof.should.be.an('object');
+          // ensure validFrom is present and has correct timestamp
+          verifiableCredential.should.have.property(
+            'validFrom',
+            credential.validFrom
           );
         });
         it('should issue both "validFrom" and "validUntil"', async () => {
@@ -318,9 +338,19 @@ for(const [version, mockCredential] of versionedCredentials) {
             'Should not throw when issuing VC with both "validFrom" and' +
               '"validUntil"'
           );
-          should.exist(
-            verifiableCredential,
-            'Expected VC to be issued with both "validFrom" and "validUntil"'
+          verifiableCredential.should.exist;
+          verifiableCredential.should.be.an('object');
+          verifiableCredential.should.have.property('proof');
+          verifiableCredential.proof.should.be.an('object');
+          // ensure validUntil & validAfter are present
+          // and have correct timestamps
+          verifiableCredential.should.have.property(
+            'validFrom',
+            credential.validFrom
+          );
+          verifiableCredential.should.have.property(
+            'validUntil',
+            credential.validUntil
           );
         });
       }

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -226,8 +226,8 @@ for(const [version, mockCredential] of versionedCredentials) {
         it('should issue "validUntil" in the past', async () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
-          credential.validUntil = '2025-10-31T19:21:25Z';
-          const now = '2022-06-30T19:21:25Z';
+          credential.validUntil = '2022-10-31T19:21:25Z';
+          const now = '2025-06-30T19:21:25Z';
           let error;
           let result;
           try {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1016,7 +1016,7 @@ for(const [version, mockCredential] of versionedCredentials) {
           } catch(e) {
             error = e;
           }
-          should.not.exist(error,
+          should.exist(error,
             'Should throw error when verifying "validFrom" in future');
         });
         it('should verify "validFrom" in the past', () => {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -197,6 +197,64 @@ for(const [version, mockCredential] of versionedCredentials) {
         error.message.should
           .contain('"suite.verificationMethod" property is required.');
       });
+      if(version === 2.0) {
+        it('should issue "validUntil" in the future', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validUntil = '2025-10-31T19:21:25Z';
+          const now = '2022-06-30T19:21:25Z';
+          let error;
+          try {
+            vc.issue({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(error,
+            'Should not throw error when issuing "validUntil" in future');
+        });
+        it('should issue "validUntil" in the past', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validUntil = '2025-10-31T19:21:25Z';
+          const now = '2022-06-30T19:21:25Z';
+          let error;
+          try {
+            vc.issue({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(error,
+            'Should not throw error when issuing with "validUntil" in past');
+        });
+        it('should issue "validFrom" in the past', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validFrom = '2022-06-30T19:21:25Z';
+          const now = '2022-10-30T19:21:25Z';
+          let error;
+          try {
+            vc.issue({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(error,
+            'Should not throw error when issuing "validFrom" in past');
+        });
+        it('should issue "validFrom" in the future', () => {
+          const credential = jsonld.clone(mockCredential);
+          credential.issuer = 'did:example:12345';
+          credential.validFrom = '2022-10-30T19:21:25Z';
+          const now = '2022-06-30T19:21:25Z';
+          let error;
+          try {
+            vc.issue({credential, now});
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(error,
+            'Should not throw error when issuing "validFrom" in future');
+        });
+      }
     });
 
     describe('vc.createPresentation()', () => {
@@ -878,34 +936,6 @@ for(const [version, mockCredential] of versionedCredentials) {
         });
       }
       if(version === 2.0) {
-        it('should issue "validFrom" in the past', () => {
-          const credential = jsonld.clone(mockCredential);
-          credential.issuer = 'did:example:12345';
-          credential.validFrom = '2022-06-30T19:21:25Z';
-          const now = '2022-10-30T19:21:25Z';
-          let error;
-          try {
-            vc._checkCredential({credential, now});
-          } catch(e) {
-            error = e;
-          }
-          should.not.exist(error,
-            'Should not throw error when issuing "validFrom" in past');
-        });
-        it('should issue "validFrom" in the future', () => {
-          const credential = jsonld.clone(mockCredential);
-          credential.issuer = 'did:example:12345';
-          credential.validFrom = '2022-10-30T19:21:25Z';
-          const now = '2022-06-30T19:21:25Z';
-          let error;
-          try {
-            vc._checkCredential({credential, now});
-          } catch(e) {
-            error = e;
-          }
-          should.not.exist(error,
-            'Should not throw error when issuing "validFrom" in future');
-        });
         it('should NOT verify "validFrom" in the future', () => {
           const credential = jsonld.clone(mockCredential);
           credential.issuer = 'did:example:12345';
@@ -933,34 +963,6 @@ for(const [version, mockCredential] of versionedCredentials) {
           }
           should.not.exist(error,
             'Should not throw error when "validFrom" in past');
-        });
-        it('should issue "validUntil" in the future', () => {
-          const credential = jsonld.clone(mockCredential);
-          credential.issuer = 'did:example:12345';
-          credential.validUntil = '2025-10-31T19:21:25Z';
-          const now = '2022-06-30T19:21:25Z';
-          let error;
-          try {
-            vc._checkCredential({credential, now});
-          } catch(e) {
-            error = e;
-          }
-          should.not.exist(error,
-            'Should not throw error when issuing "validUntil" in future');
-        });
-        it('should issue "validUntil" in the past', () => {
-          const credential = jsonld.clone(mockCredential);
-          credential.issuer = 'did:example:12345';
-          credential.validUntil = '2025-10-31T19:21:25Z';
-          const now = '2022-06-30T19:21:25Z';
-          let error;
-          try {
-            vc._checkCredential({credential, now});
-          } catch(e) {
-            error = e;
-          }
-          should.not.exist(error,
-            'Should not throw error when issuing with "validUntil" in past');
         });
         it('should NOT verify if "validUntil" in the past', () => {
           const credential = jsonld.clone(mockCredential);

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -1036,8 +1036,8 @@ for(const [version, mockCredential] of versionedCredentials) {
         it('should NOT verify if "validUntil" in the past', () => {
           const credential = mockCredential();
           credential.issuer = 'did:example:12345';
-          credential.validUntil = '2025-06-31T19:21:25Z';
-          const now = '2022-10-30T19:21:25Z';
+          credential.validUntil = '2022-06-31T19:21:25Z';
+          const now = '2025-10-30T19:21:25Z';
           let error;
           try {
             vc._checkCredential({credential, now});

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -6,22 +6,23 @@ chai.should();
 
 import * as vc from '../lib/index.js';
 
+const assertDateTime = (date, bool) =>
+  vc.dateRegex.test(date).should.equal(bool);
+
 describe('verifies RFC3339 Dates', function() {
   it('verify a valid date', function() {
     const latest = new Date().toISOString();
-    vc.dateRegex.test(latest).should.be.true;
+    assertDateTime(latest, true);
   });
-  it('verify a valid date with lowercase t', function() {
+  it('does not verify a valid date with lowercase t', function() {
     const latest = new Date().toISOString().toLowerCase();
-    vc.dateRegex.test(latest).should.be.true;
+    assertDateTime(latest, false);
   });
 
   it('should not verify an invalid date', function() {
-    const invalid = '2017/09/27';
-    vc.dateRegex.test(invalid).should.be.false;
+    assertDateTime('2017/09/27', false);
   });
   it('should not verify 2 digit years', function() {
-    const invalid = '17-09-27T22:07:22.563z';
-    vc.dateRegex.test(invalid).should.be.false;
+    assertDateTime('17-09-27T22:07:22.563Z', false);
   });
 });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -9,7 +9,7 @@ import * as vc from '../lib/index.js';
 const assertDateTime = (date, bool) =>
   vc.dateRegex.test(date).should.equal(bool);
 
-describe('verifies XML Schema Dates', function() {
+describe('verifies XML Schema DateTime', function() {
   describe('positive', function() {
     it('should accept an ISOString', function() {
       const latest = new Date().toISOString();
@@ -28,6 +28,9 @@ describe('verifies XML Schema Dates', function() {
     it('should accept a date with lowercase z', function() {
       assertDateTime('2019-03-26T14:00:00z', true);
     });
+    it('should accept a comma as a decimal sign', function() {
+      assertDateTime('2019-03-26T14:00:00,999Z', true);
+    });
   });
   describe('negative', function() {
     it('should not accept a date with lowercase t', function() {
@@ -38,6 +41,18 @@ describe('verifies XML Schema Dates', function() {
     });
     it('should not accept 2 digit years', function() {
       assertDateTime('17-09-27T22:07:22.563Z', false);
+    });
+    it('should not accept a basic ISO DateTime', function() {
+      assertDateTime('20190326T1400Z', false);
+    });
+    it('should not accept a 0 as a month', function() {
+      assertDateTime('2019-00-26T14:00:00Z', false);
+    });
+    it('should not accept a 0 as a day', function() {
+      assertDateTime('2019-01-00T14:00:00Z', false);
+    });
+    it('should not accept a time past midnight', function() {
+      assertDateTime('2019-03-25T24:01:00Z', false);
     });
   });
 });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -25,21 +25,24 @@ describe('verifies XML Schema DateTime', function() {
     it('should accept a date with a negative 4 digit year', function() {
       assertDateTime('-9999-03-26T14:00:00Z', true);
     });
-    it('should accept a date with lowercase z', function() {
-      assertDateTime('2019-03-26T14:00:00z', true);
-    });
-    it('should accept a comma as a decimal sign', function() {
-      assertDateTime('2019-03-26T14:00:00,999Z', true);
-    });
     it('should accept 24:00 as an hour', function() {
       assertDateTime('2019-03-26T24:00:00Z', true);
+    });
+    it('should accept a positive offset', function() {
+      assertDateTime('2019-03-26T24:00:00+05:00', true);
+    });
+    it('should accept a negative offset', function() {
+      assertDateTime('2019-03-26T24:00:00-05:00', true);
+    });
+    it('should accept a date not ending in a z', function() {
+      assertDateTime('2019-03-26T14:00:00', true);
     });
   });
   describe('negative', function() {
     it('should not accept a date with lowercase t', function() {
       assertDateTime('2019-03-26t14:00:00Z', false);
     });
-    it('should not accept an invalid date', function() {
+    it('should not accept a date with "/" as a separator', function() {
       assertDateTime('2017/09/27', false);
     });
     it('should not accept 2 digit years', function() {

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -31,6 +31,9 @@ describe('verifies XML Schema DateTime', function() {
     it('should accept a comma as a decimal sign', function() {
       assertDateTime('2019-03-26T14:00:00,999Z', true);
     });
+    it('should accept 24:00 as an hour', function() {
+      assertDateTime('2019-03-26T24:00:00Z', true);
+    });
   });
   describe('negative', function() {
     it('should not accept a date with lowercase t', function() {

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -39,6 +39,9 @@ describe('verifies XML Schema DateTime', function() {
     });
   });
   describe('negative', function() {
+    it('should not accept an empty string', function() {
+      assertDateTime('', false);
+    });
     it('should not accept a date with lowercase t', function() {
       assertDateTime('2019-03-26t14:00:00Z', false);
     });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -58,7 +58,7 @@ describe('verifies XML Schema DateTime', function() {
       assertDateTime('2019-00-26T14:00:00Z', false);
     });
     it('should not accept 13 as a month', function() {
-      assertDateTime('2019-00-26T14:00:00Z', false);
+      assertDateTime('2019-13-26T14:00:00Z', false);
     });
     it('should not accept 00 as a day', function() {
       assertDateTime('2019-01-00T14:00:00Z', false);

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -10,19 +10,34 @@ const assertDateTime = (date, bool) =>
   vc.dateRegex.test(date).should.equal(bool);
 
 describe('verifies XML Schema Dates', function() {
-  it('verify a valid date', function() {
-    const latest = new Date().toISOString();
-    assertDateTime(latest, true);
+  describe('positive', function() {
+    it('should accept an ISOString', function() {
+      const latest = new Date().toISOString();
+      assertDateTime(latest, true);
+    });
+    it('should accept a date with a 4 digit year', function() {
+      const latest = '2019-03-26T14:00:00Z';
+      assertDateTime(latest, true);
+    });
+    it('should accept a date with a > 4 digit year', function() {
+      assertDateTime('99999-03-26T14:00:00Z', true);
+    });
+    it('should accept a date with a negative 4 digit year', function() {
+      assertDateTime('-9999-03-26T14:00:00Z', true);
+    });
+    it('should accept a date with lowercase z', function() {
+      assertDateTime('2019-03-26T14:00:00z', true);
+    });
   });
-  it('does not verify a valid date with lowercase t', function() {
-    const latest = new Date().toISOString().toLowerCase();
-    assertDateTime(latest, false);
-  });
-
-  it('should not verify an invalid date', function() {
-    assertDateTime('2017/09/27', false);
-  });
-  it('should not verify 2 digit years', function() {
-    assertDateTime('17-09-27T22:07:22.563Z', false);
+  describe('negative', function() {
+    it('should not accept a date with lowercase t', function() {
+      assertDateTime('2019-03-26t14:00:00Z', false);
+    });
+    it('should not accept an invalid date', function() {
+      assertDateTime('2017/09/27', false);
+    });
+    it('should not accept 2 digit years', function() {
+      assertDateTime('17-09-27T22:07:22.563Z', false);
+    });
   });
 });

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -9,7 +9,7 @@ import * as vc from '../lib/index.js';
 const assertDateTime = (date, bool) =>
   vc.dateRegex.test(date).should.equal(bool);
 
-describe('verifies RFC3339 Dates', function() {
+describe('verifies XML Schema Dates', function() {
   it('verify a valid date', function() {
     const latest = new Date().toISOString();
     assertDateTime(latest, true);

--- a/test/20-dateRegex.spec.js
+++ b/test/20-dateRegex.spec.js
@@ -45,11 +45,17 @@ describe('verifies XML Schema DateTime', function() {
     it('should not accept a basic ISO DateTime', function() {
       assertDateTime('20190326T1400Z', false);
     });
-    it('should not accept a 0 as a month', function() {
+    it('should not accept 00 as a month', function() {
       assertDateTime('2019-00-26T14:00:00Z', false);
     });
-    it('should not accept a 0 as a day', function() {
+    it('should not accept 13 as a month', function() {
+      assertDateTime('2019-00-26T14:00:00Z', false);
+    });
+    it('should not accept 00 as a day', function() {
       assertDateTime('2019-01-00T14:00:00Z', false);
+    });
+    it('should not accept 32 as a day', function() {
+      assertDateTime('2019-01-32T14:00:00Z', false);
     });
     it('should not accept a time past midnight', function() {
       assertDateTime('2019-03-25T24:01:00Z', false);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,5 @@
+export function createTimeStamp({date}) {
+  const isoString = date.toISOString();
+  // remove the milliseconds from the iso time stamp
+  return isoString.substr(0, isoString.length - 5) + 'Z';
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,10 +1,13 @@
-export function createTimeStamp({date}) {
-  const isoString = date.toISOString();
-  // remove the milliseconds from the iso time stamp
-  return isoString.substr(0, isoString.length - 5) + 'Z';
-}
-
+/**
+ * Creates an ISO DateTime skewed by a number of years
+ *
+ * @param {object} options - Options to use.
+ * @param {Date} [options.date = new Date()] - An optional  date to use.
+ * @param {number} options.skewYear - A number to skew the year.
+ *
+ * @returns {string} Returns an ISO DateTime String.
+ */
 export function createSkewedTimeStamp({date = new Date(), skewYear}) {
   date.setFullYear(date.getFullYear() + skewYear);
-  return createTimeStamp({date});
+  return date.toISOString();
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,5 +10,5 @@
 export function createSkewedTimeStamp({date = new Date(), skewYear}) {
   date.setFullYear(date.getFullYear() + skewYear);
   const isoString = date.toISOString();
-  return `${isoString.substring(0, isoString.length - 5)}Z`;;
+  return `${isoString.substring(0, isoString.length - 5)}Z`;
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,5 +10,5 @@
 export function createSkewedTimeStamp({date = new Date(), skewYear}) {
   date.setFullYear(date.getFullYear() + skewYear);
   const isoString = date.toISOString();
-  return isoString.substr(0, isoString.length - 5) + 'Z';
+  return `${isoString.substring(0, isoString.length - 5)}Z`;;
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,3 +3,8 @@ export function createTimeStamp({date}) {
   // remove the milliseconds from the iso time stamp
   return isoString.substr(0, isoString.length - 5) + 'Z';
 }
+
+export function createSkewedTimeStamp({date = new Date(), skewYear}) {
+  date.setFullYear(date.getFullYear() + skewYear);
+  return createTimeStamp({date});
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,5 +9,6 @@
  */
 export function createSkewedTimeStamp({date = new Date(), skewYear}) {
   date.setFullYear(date.getFullYear() + skewYear);
-  return date.toISOString();
+  const isoString = date.toISOString();
+  return isoString.substr(0, isoString.length - 5) + 'Z';
 }

--- a/test/mocks/mock.data.js
+++ b/test/mocks/mock.data.js
@@ -29,7 +29,7 @@ const _mixedCredential = () => {
   };
 };
 
-const credentials = mock.credentials = {};
+export const credentials = mock.credentials = {};
 credentials.mixed = _mixedCredential();
 
 credentials.alpha = {


### PR DESCRIPTION
Features:

1. changes the DateRegexp to an XML schema DateTime and expands tests on it
2. move expirationDate into the VC 1.0 validators and only checks date when mode is verify
3. adds validUntil and associated tests
4. adds validFrom and associated tests
5. make some minor corrections with test data for better consistency
6. This pr now contains `credentialStatus` check changes from [here](https://github.com/digitalbazaar/vc/pull/170)
7. Makes `credentialStatus.id` optional
8. Checks to ensure if `credentialStatus.id` is present it must be a URL.