### PR TITLE
Update credentialStatus checks.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -674,17 +674,18 @@ export function _checkCredential({
     _validateUriId({id: issuer, propertyName: 'issuer'});
   }
 
-  if('credentialStatus' in credential) {
-    const {credentialStatus} = credential;
-    if(Array.isArray(credentialStatus) ?
-      credentialStatus.some(cs => !cs.id) : !credentialStatus.id) {
-      throw new Error('"credentialStatus" must include an id.');
+  // check credentialStatus
+  jsonld.getValues(credential, 'credentialStatus').forEach(cs => {
+    // check if optional "id" is a URL
+    if('id' in cs) {
+      _validateUriId({id: cs.id, propertyName: 'credentialStatus.id'});
     }
-    if(Array.isArray(credentialStatus) ?
-      credentialStatus.some(cs => !cs.type) : !credentialStatus.type) {
+
+    // check "type" present
+    if(!cs.type) {
       throw new Error('"credentialStatus" must include a type.');
     }
-  }
+  });
 
   // check evidences are URLs
   jsonld.getValues(credential, 'evidence').forEach(evidence => {

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -809,6 +809,40 @@ for(const [version, mockCredential] of versionedCredentials) {
           .contain('"issuer" must be a URI');
       });
 
+      it('should reject credentialStatus that is not a URI', () => {
+        const credential = mockCredential();
+        credential.credentialStatus = {
+          id: 'not-a-url',
+          type: 'urn:type'
+        };
+        let error;
+        try {
+          vc._checkCredential({credential});
+        } catch(e) {
+          error = e;
+        }
+        should.exist(error,
+          'Should throw error when "evidence" is not a URI');
+        error.should.be.instanceof(TypeError);
+        error.message.should
+          .contain('"credentialStatus.id" must be a URI');
+      });
+
+      it('should accept "credentialStatus" with no "id"', () => {
+        const credential = mockCredential();
+        credential.credentialStatus = {
+          type: 'urn:type'
+        };
+        let error;
+        try {
+          vc._checkCredential({credential});
+        } catch(e) {
+          error = e;
+        }
+        should.not.exist(error,
+          'Should not throw error when "credentialStatus.id" is absent');
+      });
+
       it('should reject an evidence id that is not a URI', () => {
         const credential = mockCredential();
         credential.issuer = 'did:example:12345';


### PR DESCRIPTION
- Make "id" optional.
- If "id" present, check it's a URL.
- Add tests.

This matches 1.x spec, and is currently an open issue in 2.0 work.