### PR TITLE
Adds a `bbs-2023` test to the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ const {
   createVerifyCryptosuite
 } = ecdsaSd2023Cryptosuite;
 
+// sample ecdsa key pair used to issue the sample VC
+const keyPair = {
+  "@context": "https://w3id.org/security/multikey/v1",
+  "id": "https://example.edu/issuers/keys/2",
+  "type": "Multikey",
+  "controller": "https://example.edu/issuers/565049",
+  "publicKeyMultibase": "zDnaeWJjGpXnQAbEpRur3kSWFapGZbwGnFCkzyhiq7nDeXXrM",
+  "secretKeyMultibase": "z42trzSpncjWFaB9cKE2Gg5hxtbuAQa5mVJgGwjrugHMacdM"
+};
+
 // sample VC
 const verifiableCredential = {
   "@context": [
@@ -274,13 +284,13 @@ const verifiableCredential = {
     "alumniOf": "<span lang=\"en\">Example University</span>"
   },
   "proof": {
-    "id": "urn:uuid:2ef8c7ce-a4da-44b4-ba7f-3d43eaf1e50c",
+    "id": "urn:uuid:318d9dce-bc7b-40b9-a956-c9160bf910db",
     "type": "DataIntegrityProof",
-    "created": "2023-11-13T22:58:06Z",
+    "created": "2024-01-12T21:53:11Z",
     "verificationMethod": "https://example.edu/issuers/keys/2",
     "cryptosuite": "ecdsa-sd-2023",
     "proofPurpose": "assertionMethod",
-    "proofValue": "u2V0AhVhAtYPKUQxwULXzMdsAfqtipsiX6YEPURYSBFYxoFY-v0vCPyAs1Ckyy61Wtk3xZWyBGNaEr3w0wQiJHHd5B9uR-1gjgCQCVtFPMk-ECi0CJFYv_GTjCChf8St0FQjuExTAnwP0-ipYIOHSun3YqabOfNe2DYFkHBTZa0Csf1a7YUDW8hhsOHqTglhA8aqnyanT-Ybo2-aHBTcI-UmHX0iluGb2IxoHLLhQoOPm2rDW0eB04Fa2Dh6WMKoOl_Bz3wZZDGQ31XoGrQvgIlhAo8qspvC-QQ-xI3KADiA12sO5LRsZ7hl9ozoJEECVsDOKlxWd-dhices5b2ZQIiiRE9XxxJx8YuwCMoD2bRLbOIJtL2lzc3VhbmNlRGF0ZWcvaXNzdWVy"
+    "proofValue": "u2V0AhVhAsl6PQKYE15R0O5Qd267ntwHGNH6JRvZ1y8A-fTCQLUoupP8SCZzzmyc0a1AnabHEVKhpHtYV8j9Kapp-fHFBtFgjgCQCIMn2L1R7D5VPnNn_2foxdj8qvsuUTGFqA34YBkguzCpYILfJ-qNQpn6_dJGpkG24FynqbHpnzoHWVJc2kiLqEKHRglhAUmZtstR9MOLrZjcR8J303MXFvRiE6J3bbaPT1_I9-6578-Wj-eydv2TEGBq_dmsjxsOh4_2Va0etw8CXXMAzaVhA9fr7_Sl9D67AfvLhkJTZ0uJCAXcbL2MaS-DmoC7K-ABxroL1_wj119J8yTMlazxzYBwYkihrdp4ZWJZxraX9tIJtL2lzc3VhbmNlRGF0ZWcvaXNzdWVy"
   }
 };
 
@@ -320,7 +330,7 @@ const {
   createVerifyCryptosuite
 } = bbs2023Cryptosuite;
 
-// sample BBS key pair
+// sample BBS key pair used to issue sample VC below
 const bbsKeyPair = {
   "@context": "https://w3id.org/security/multikey/v1",
   "id": "https://example.edu/issuers/keys/3",

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ const ecdsaKeyPair = await EcdsaMultikey.generate({
   controller: 'https://example.edu/issuers/565049'
 });
 
+// sample exported key pair
+/*
+{
+  "@context": "https://w3id.org/security/multikey/v1",
+  "id": "https://example.edu/issuers/keys/2",
+  "type": "Multikey",
+  "controller": "https://example.edu/issuers/565049",
+  "publicKeyMultibase": "zDnaeWJjGpXnQAbEpRur3kSWFapGZbwGnFCkzyhiq7nDeXXrM",
+  "secretKeyMultibase": "z42trzSpncjWFaB9cKE2Gg5hxtbuAQa5mVJgGwjrugHMacdM"
+}
+*/
+
 // sample unsigned credential
 const credential = {
   "@context": [
@@ -192,6 +204,18 @@ const bbsKeyPair = await bls12381Multikey.generate({
   id: 'https://example.edu/issuers/keys/3',
   controller: 'https://example.edu/issuers/565049'
 });
+
+// sample exported key pair
+/*
+{
+  "@context": "https://w3id.org/security/multikey/v1",
+  "id": "https://example.edu/issuers/keys/3",
+  "type": "Multikey",
+  "controller": "https://example.edu/issuers/565049",
+  "publicKeyMultibase": "zUC7LWtcV5GK9RRemm7wdcSF2cqAz2zL8SJD5f1yHFcTkUvGGcQ6mH4PiMmYjRE2qy5u8fuDhYAnd8uKzZ8eTaeD6U1UdxwHJ19A8wEjqiBkEkw9uwn42DY4bkUch3oYf6uQJr4",
+  "secretKeyMultibase": "z488v2JUe42rQXeUVkStpgze5k5LnR7T9Brgr8gCHTNTrWoC"
+}
+*/
 
 // sample unsigned credential
 const credential = {
@@ -254,16 +278,6 @@ const {
   createSignCryptosuite,
   createVerifyCryptosuite
 } = ecdsaSd2023Cryptosuite;
-
-// sample ecdsa key pair used to issue the sample VC
-const keyPair = {
-  "@context": "https://w3id.org/security/multikey/v1",
-  "id": "https://example.edu/issuers/keys/2",
-  "type": "Multikey",
-  "controller": "https://example.edu/issuers/565049",
-  "publicKeyMultibase": "zDnaeWJjGpXnQAbEpRur3kSWFapGZbwGnFCkzyhiq7nDeXXrM",
-  "secretKeyMultibase": "z42trzSpncjWFaB9cKE2Gg5hxtbuAQa5mVJgGwjrugHMacdM"
-};
 
 // sample VC
 const verifiableCredential = {
@@ -329,16 +343,6 @@ const {
   createSignCryptosuite,
   createVerifyCryptosuite
 } = bbs2023Cryptosuite;
-
-// sample BBS key pair used to issue sample VC below
-const bbsKeyPair = {
-  "@context": "https://w3id.org/security/multikey/v1",
-  "id": "https://example.edu/issuers/keys/3",
-  "type": "Multikey",
-  "controller": "https://example.edu/issuers/565049",
-  "publicKeyMultibase": "zUC7LWtcV5GK9RRemm7wdcSF2cqAz2zL8SJD5f1yHFcTkUvGGcQ6mH4PiMmYjRE2qy5u8fuDhYAnd8uKzZ8eTaeD6U1UdxwHJ19A8wEjqiBkEkw9uwn42DY4bkUch3oYf6uQJr4",
-  "secretKeyMultibase": "z488v2JUe42rQXeUVkStpgze5k5LnR7T9Brgr8gCHTNTrWoC"
-};
 
 // sample VC
 const verifiableCredential = {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "jsonld-signatures": "^11.2.1"
   },
   "devDependencies": {
+    "@digitalbazaar/bbs-2023-cryptosuite": "digitalbazaar/bbs-2023-cryptosuite#refactor",
+    "@digitalbazaar/bls12-381-multikey": "^1.1.1",
     "@digitalbazaar/credentials-examples-context": "^1.0.0",
     "@digitalbazaar/data-integrity": "^2.0.0",
     "@digitalbazaar/data-integrity-context": "^2.0.0",


### PR DESCRIPTION
This PR should not be merged until the `bbs-2023-cryptosuite` library used to provide the implementation is released on npm.

This PR also updates the `ecdsa-sd-2023` example to print out the generated key pair used.