### PR TITLE
Vc 2.0 Style nit: ensure credentials includes version.

### DIFF
--- a/lib/contexts/index.js
+++ b/lib/contexts/index.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2019-2023 Digital Bazaar, Inc. All rights reserved.
  */
 import {
-  contexts as credentialsContexts
+  contexts as credentialsV1Contexts
 } from 'credentials-context';
 import {
   contexts as credentialsV2Contexts
@@ -17,5 +17,5 @@ const addContexts = _contexts => {
   }
 };
 
-addContexts(credentialsContexts);
+addContexts(credentialsV1Contexts);
 addContexts(credentialsV2Contexts);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,15 +1,15 @@
 /*!
  * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
  */
-import * as credentialsContext from 'credentials-context';
-import * as credentialsContextV2 from '@digitalbazaar/credentials-v2-context';
+import * as credentialsV1 from 'credentials-context';
+import * as credentialsV2 from '@digitalbazaar/credentials-v2-context';
 
-export const {constants: {CREDENTIALS_CONTEXT_V1_URL}} = credentialsContext;
+export const {constants: {CREDENTIALS_CONTEXT_V1_URL}} = credentialsV1;
 export const {
   constants: {
     CONTEXT_URL: CREDENTIALS_CONTEXT_V2_URL
   }
-} = credentialsContextV2;
+} = credentialsV2;
 // Z and T must be uppercase
 // xml schema date time RegExp
 // @see https://www.w3.org/TR/xmlschema11-2/#dateTime

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,6 +1,7 @@
 export default {
   CREDENTIALS_CONTEXT_URL: 'https://www.w3.org/ns/credentials/v2',
   CREDENTIALS_CONTEXT_V1_URL: 'https://www.w3.org/2018/credentials/v1',
+  CREDENTIALS_CONTEXT_V2_URL: 'https://www.w3.org/ns/credentials/v2',
   DID_CONTEXT_URL: 'https://www.w3.org/ns/did/v1',
   VERES_ONE_CONTEXT_URL: 'https://w3id.org/veres-one/v1'
 };

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,5 +1,4 @@
 export default {
-  CREDENTIALS_CONTEXT_URL: 'https://www.w3.org/ns/credentials/v2',
   CREDENTIALS_CONTEXT_V1_URL: 'https://www.w3.org/2018/credentials/v1',
   CREDENTIALS_CONTEXT_V2_URL: 'https://www.w3.org/ns/credentials/v2',
   DID_CONTEXT_URL: 'https://www.w3.org/ns/did/v1',

--- a/test/mocks/mock.data.js
+++ b/test/mocks/mock.data.js
@@ -34,7 +34,7 @@ credentials.mixed = _mixedCredential();
 
 credentials.alpha = {
   "@context": [
-    constants.CREDENTIALS_CONTEXT_URL, {
+    constants.CREDENTIALS_CONTEXT_V2_URL, {
       "ex1": "https://example.com/examples/v1",
       "AlumniCredential": "ex1:AlumniCredential",
       "alumniOf": "ex1:alumniOf"
@@ -51,7 +51,7 @@ credentials.alpha = {
 const presentations = mock.presentations = {};
 
 presentations.alpha = {
-  "@context": [constants.CREDENTIALS_CONTEXT_URL],
+  "@context": [constants.CREDENTIALS_CONTEXT_V2_URL],
   "type": ["VerifiablePresentation"],
   "verifiableCredential": [],
 };


### PR DESCRIPTION
just makes the imports of the credentials context each contain a version to remove ambiguity between which context each import refers to.